### PR TITLE
Add gh-stars

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Table of Contents
 * [**org-users**](https://github.com/yermulnik/gh-org-users) - GH CLI extension to list all GutHub Org users.
 * [**pulls**](https://github.com/AaronMoat/gh-pulls) - View all open pull requests you have created.
 * [**repo-collab**](https://github.com/mislav/gh-repo-collab) - Extension to manage repository collaborators.
+* [**stars**](https://github.com/aymanbagabas/gh-stars) - GitHub stargazers in your terminal.
 * [**sql**](https://github.com/KOBA789/gh-sql) -  Query GitHub Projects (beta) with SQL.
 * [**token**](https://github.com/Link-/gh-token) -  Create an installation access token for a GitHub app from your terminal.
 * [**user-status**](https://github.com/vilmibm/gh-user-status) - Set and get github user statuses.


### PR DESCRIPTION
[gh-stars](https://github.com/aymanbagabas/gh-stars) displays Github stargazers over time in your terminal. It also has a table view to show stars count per day.