### PR TITLE
Added gh-py to tools list

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Table of Contents
 * [**user-status**](https://github.com/vilmibm/gh-user-status) - Set and get github user statuses.
 
 ## Tool
+* [**GH-PY**](https://github.com/JessicaTegner/gh-py) - Write gh extensions from python, that's portable, with full support for installing packages.
 * [**changelog**](https://github.com/chelnak/gh-changelog) - Extension for creating changelogs that adhere to the [keep a changelog](https://keepachangelog.com/en/1.0.0/) specification.
 * [**clone-org**](https://github.com/matt-bartel/gh-clone-org) - Extension script to clone all repositories in an organization.
 * [**cp**](https://github.com/mislav/gh-cp) - Extension to copy a file from a GitHub repository locally without cloning the repository.


### PR DESCRIPTION
Hi there.

I have created a tool that makes it much easier to write gh extensions from python.

I have added it to the tools section, but feel free to move it around, if it fits in other (or multiple) categories.
