### PR TITLE
Add `gh-profile`

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Table of Contents
 * [**net**](https://github.com/github/gh-net) - Network bridge for [GitHub Codespaces](https://github.com/features/codespaces).
 * [**notify**](https://github.com/meiji163/gh-notify) - Extension to display GitHub notifications.
 * [**org-users**](https://github.com/yermulnik/gh-org-users) - GH CLI extension to list all GitHub Org users.
+* [**profile**](https://github.com/gabe565/gh-profile) - Extension that allows you to use multiple GitHub accounts with the gh cli.
 * [**pulls**](https://github.com/AaronMoat/gh-pulls) - View all open pull requests you have created.
 * [**repo-collab**](https://github.com/mislav/gh-repo-collab) - Extension to manage repository collaborators.
 * [**stars**](https://github.com/aymanbagabas/gh-stars) - GitHub stargazers in your terminal.


### PR DESCRIPTION
[gh-profile](https://github.com/gabe565/gh-profile) allows you to use multiple GitHub accounts with the gh cli. It supports switching accounts and activating accounts in certain directories.