### PR TITLE
Added gh-validate-repo extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Table of Contents
 * [**semver**](https://github.com/koozz/gh-semver) - This GitHub CLI extension can be used determine the semantic version to release.
 * [**timer**](https://github.com/anmalkov/gh-timer) - Extension that runs a timer or stopwatch.
 * [**user-stars**](https://github.com/korosuke613/gh-user-stars) - Extension that displays an interactive list of your github stars.
+* [**validate-repo**](https://github.com/govindsme/gh-validate-repo) - Extension that validates a cloned reposiory against a list of checks.
 * [**workon**](https://github.com/chmouel/gh-workon/) - Create a branch or a commit message from an issue title and assign yourself to it. 
 
 ## Fun


### PR DESCRIPTION
This extension will help you to validate a repository that is cloned. Though this extension has some overlaps with pre-commit, it differs on the followign

- This exension focuses on ensuring validations that are not specific to code quality will also be checked.
- gh cli native where as pre-commit requires an explicit installation of the tool
