### PR TITLE
Add gh-sub-issue extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Table of Contents
 - [**repo-collab**](https://github.com/mislav/gh-repo-collab) - Extension to manage repository collaborators.
 - [**stars**](https://github.com/aymanbagabas/gh-stars) - GitHub stargazers in your terminal.
 - [**sql**](https://github.com/KOBA789/gh-sql) - Query GitHub Projects (beta) with SQL.
+- [**sub-issue**](https://github.com/yahsan2/gh-sub-issue) - Manage sub-issues (child issues) and create hierarchical task structures by linking issues as parent-child relationships.
 - [**token**](https://github.com/Link-/gh-token) - Create an installation access token for a GitHub app from your terminal.
 - [**user-status**](https://github.com/vilmibm/gh-user-status) - Set and get github user statuses.
 - [**xplr**](https://github.com/sayanarijit/gh-xplr) - Explore GitHub repos using xplr via GitHub CLI.


### PR DESCRIPTION
## Description
Add gh-sub-issue to the GitHub extensions section.

## What is gh-sub-issue?
gh-sub-issue is a GitHub CLI extension for managing sub-issues (child issues). It allows users to create hierarchical task structures by linking issues as parent-child relationships.

## Key Features
- Link existing issues as sub-issues
- Create new sub-issues directly linked to a parent
- List all sub-issues connected to a parent issue
- Remove sub-issue relationships
- Support for multiple output formats (TTY, plain text, JSON)
- Cross-repository support

## Links
- Repository: https://github.com/yahsan2/gh-sub-issue
- Installation: `gh extension install yahsan2/gh-sub-issue`

Thank you for considering this addition!