### PR TITLE
Add gh-label-sync and gh-milestone-manager extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Table of Contents
 - [**gr**](https://github.com/sarumaj/gh-gr) - Pull, push and check status on multiple GitHub repositories at once.
 - [**hook**](https://github.com/lucasmelin/gh-hook) - Extension to easily manage your github repository webhooks.
 - [**label**](https://github.com/heaths/gh-label) - Extension for issue label management.
+- [**label-sync**](https://github.com/scttfrdmn/gh-label-sync) - Extension for bulk label management and synchronization from YAML/JSON/CSV files.
 - [**look**](https://github.com/LangLangBart/gh-look) - Interactive gh tool: drop an emoji, write comments, star repositories, etc.
 - [**ls**](https://github.com/wuwe1/gh-ls) - GitHub CLI to list contents of GitHub repo.
 - [**metrics**](https://github.com/hectcastro/gh-metrics) - Extension that provides summary pull request metrics.

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Table of Contents
 - [**ls**](https://github.com/wuwe1/gh-ls) - GitHub CLI to list contents of GitHub repo.
 - [**metrics**](https://github.com/hectcastro/gh-metrics) - Extension that provides summary pull request metrics.
 - [**milestone**](https://github.com/valeriobelli/gh-milestone) - GitHub CLI extension for managing milestones.
+- [**milestone-manager**](https://github.com/scttfrdmn/gh-milestone-manager) - Comprehensive milestone management with beautiful formatting, close/reopen commands, and detailed progress tracking.
 - [**net**](https://github.com/github/gh-net) - Network bridge for [GitHub Codespaces](https://github.com/features/codespaces).
 - [**notify**](https://github.com/meiji163/gh-notify) - Extension to display GitHub notifications.
 - [**org-users**](https://github.com/yermulnik/gh-org-users) - GH CLI extension to list all GitHub Org users.


### PR DESCRIPTION
## Description

This PR adds two GitHub CLI extensions to the awesome list:
1. [gh-label-sync](https://github.com/scttfrdmn/gh-label-sync)
2. [gh-milestone-manager](https://github.com/scttfrdmn/gh-milestone-manager)

---

## gh-label-sync

A GitHub CLI extension for bulk label management and synchronization from YAML/JSON/CSV files.

### Key Features:
- 📁 Multi-format support (YAML, JSON, CSV)
- 🔄 Intelligent diffing shows exactly what will change
- 🛡️ Safe preview mode with `--dry-run`
- 📤 Export existing labels to any format
- 🔁 Clone labels between repositories
- 🎯 Fine-grained control with `--force` and `--delete-unmanaged` flags

### Why it's useful:
Setting up labels in new repositories or syncing label changes across multiple repos is tedious with the GitHub web UI. This extension provides declarative label management that makes it easy to maintain consistent labels across an organization.

### Installation:
```bash
gh extension install scttfrdmn/gh-label-sync
```

---

## gh-milestone-manager

A comprehensive GitHub CLI extension for milestone management with beautiful formatting and intuitive commands.

### Key Features:
✨ **Full CRUD Operations** - Create, read, update, and delete milestones
📊 **Beautiful Formatting** - Table and JSON output with progress indicators
🎯 **State Management** - Dedicated close/reopen commands (not just edit)
📅 **Due Date Management** - Multiple date format support
🔄 **Multi-Repository** - Work across different repos with `--repo` flag
🛡️ **Recently Maintained** - Active development (Dec 2025)

### Why it's useful:
GitHub CLI doesn't provide native milestone commands. This extension provides comprehensive milestone management with better UX than the existing gh-milestone extension (dedicated close/reopen commands, better formatting, active maintenance).

### Installation:
```bash
gh extension install scttfrdmn/gh-milestone-manager
```