### PR TITLE
Add pr-dashboard extension to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Table of Contents
 - [**org-users**](https://github.com/yermulnik/gh-org-users) - GH CLI extension to list all GitHub Org users.
 - [**profile**](https://github.com/gabe565/gh-profile) - Extension that allows you to use multiple GitHub accounts with the gh cli.
 - [**projects**](https://github.com/github/gh-projects) - Official extension for managing your github projects.
+- [**pr-dashboard**](https://github.com/bajaj6/gh-pr-dashboard) - A single view of every PR that needs your attention — across teams, repos.
 - [**pulls**](https://github.com/AaronMoat/gh-pulls) - View all open pull requests you have created.
 - [**repo-collab**](https://github.com/mislav/gh-repo-collab) - Extension to manage repository collaborators.
 - [**stars**](https://github.com/aymanbagabas/gh-stars) - GitHub stargazers in your terminal.


### PR DESCRIPTION
Adding the CLI extension - https://github.com/bajaj6/gh-pr-dashboard