### PR TITLE
Add gh-akf — The AI Native File Format

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Table of Contents
 
 ## Tool
 
+- [**akf**](https://github.com/HMAKT99/gh-akf) - The AI native file format. Stamp files with trust scores, provenance, and compliance metadata. Certify changed files, generate trust reports for PRs.
 - [**changelog**](https://github.com/chelnak/gh-changelog) - Extension for creating changelogs that adhere to the [keep a changelog](https://keepachangelog.com/en/1.0.0/) specification.
 - [**cl**](https://github.com/tmkx/gh-cl) - Get changelog of npm packages fastly.
 - [**clone-org**](https://github.com/matt-bartel/gh-clone-org) - Extension script to clone all repositories in an organization.


### PR DESCRIPTION
GitHub CLI extension for AKF. Stamp files with trust metadata, certify changed files, generate trust reports for PRs. https://github.com/HMAKT99/gh-akf