### PR TITLE
Add gh-image

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Table of Contents
 - [**gitignore**](https://github.com/garnertb/gh-gitignore) - Load gitignore files from GitHub into your project.
 - [**gr**](https://github.com/sarumaj/gh-gr) - Pull, push and check status on multiple GitHub repositories at once.
 - [**hook**](https://github.com/lucasmelin/gh-hook) - Extension to easily manage your github repository webhooks.
+- [**image**](https://github.com/drogers0/gh-image) - Upload local images to GitHub from the terminal, producing user-attachments URLs that work in issues, PRs, and READMEs.
 - [**label**](https://github.com/heaths/gh-label) - Extension for issue label management.
 - [**look**](https://github.com/LangLangBart/gh-look) - Interactive gh tool: drop an emoji, write comments, star repositories, etc.
 - [**ls**](https://github.com/wuwe1/gh-ls) - GitHub CLI to list contents of GitHub repo.


### PR DESCRIPTION
Adds [gh-image](https://github.com/drogers0/gh-image) to the **Github** section (alphabetically between `hook` and `label`).

`gh-image` is a `gh` CLI extension that uploads local images to GitHub from the terminal and returns ready-to-embed `user-attachments` URLs for issues, PRs, and READMEs. GitHub has no public image-upload API; this replicates the web UI's internal flow, and URLs respect repo visibility (private-repo images stay private).

- Install: `gh extension install drogers0/gh-image`
- MIT licensed, prebuilt binaries for macOS/Linux/Windows.