### PR TITLE
Add gh-attach

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Table of Contents
 
 - [**actions-cache**](https://github.com/actions/gh-actions-cache) - Extension to manage the GitHub Actions caches being used in a GitHub repository.
 - [**actions-status**](https://github.com/rsese/gh-actions-status) - An extension to view the overall health of an organization's use of actions.
+- [**attach**](https://github.com/sudosubin/gh-attach) - Upload files to GitHub user-attachments and get a URL from the terminal.
 - [**bump**](https://github.com/johnmanjiro13/gh-bump) - Extension for bumping version of a repository.
 - [**combine-prs**](https://github.com/rnorth/gh-combine-prs) - An extension for GitHub CLI that combines multiple PRs into one.
 - [**copilot-review**](https://github.com/ChrisCarini/gh-copilot-review) - Extension to request a [Copilot code review](https://github.blog/changelog/2025-04-04-copilot-code-review-now-generally-available/) on a PR.


### PR DESCRIPTION
## Summary

[gh-attach](https://github.com/sudosubin/gh-attach) turns a local file into a GitHub attachment URL in one command.

Point it at a file and it prints the link, ready to drop into an issue, PR, or README. It reads your GitHub session from the browser you're already signed into (Chrome, Firefox, Safari, Arc, and more), offers `--json`/`--jq` output for scripting, and supports GitHub Enterprise Server.