### PR TITLE
Add OutageDeck extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Table of Contents
 - [**net**](https://github.com/github/gh-net) - Network bridge for [GitHub Codespaces](https://github.com/features/codespaces).
 - [**notify**](https://github.com/meiji163/gh-notify) - Extension to display GitHub notifications.
 - [**org-users**](https://github.com/yermulnik/gh-org-users) - GH CLI extension to list all GitHub Org users.
+- [**outagedeck**](https://github.com/outagedeck/gh-outagedeck) - Check GitHub and cloud/SaaS dependency status from official vendor status feeds.
 - [**pr-todo**](https://github.com/Suree33/gh-pr-todo) - Extract TODO-style comments from pull request diffs.
 - [**profile**](https://github.com/gabe565/gh-profile) - Extension that allows you to use multiple GitHub accounts with the gh cli.
 - [**projects**](https://github.com/github/gh-projects) - Official extension for managing your github projects.


### PR DESCRIPTION
## Summary

Adds the installable `outagedeck/gh-outagedeck` extension to the GitHub section in alphabetical order.

The extension answers the operator question “is GitHub—or another dependency—reporting an incident?” from GitHub CLI. With no arguments it reports GitHub’s provider rollup plus GitHub Actions, API, and Web service states from the official GitHub status feed normalized by OutageDeck.

## Verification

- `gh extension search outagedeck` returns the public repository
- clean `gh extension install outagedeck/gh-outagedeck --pin v0.1.0` succeeded
- `gh outagedeck --version` returned `0.1.0`
- live default GitHub and provider-search commands succeeded
- repository link returns HTTP 200
- the one-line list change follows the repository’s alphabetical grouping instruction
- `git diff --check` passed

The repository’s current Awesome Lint baseline reports existing document-level errors; the new entry itself adds no lint diagnostic.

## Disclosure

I maintain OutageDeck and am submitting its extension. The contribution and extension were prepared with AI assistance, then validated with unit tests, Go vet, cross-platform builds, and a clean public install.
